### PR TITLE
Changed release version to stable instead of latest

### DIFF
--- a/cdk-rancher-ingress.yaml
+++ b/cdk-rancher-ingress.yaml
@@ -48,7 +48,7 @@ spec:
         app: rancher
     spec:
       containers:
-      - image: rancher/rancher:latest
+      - image: rancher/rancher:stable
         imagePullPolicy: Always
         name: rancher
         ports:


### PR DESCRIPTION
As opposed by the official guide from rancher we should switch to the stable version instead of latest.

> rancher/rancher:stable tag will be our latest stable release builds. This tag is the version that we recommend for production.

Source: https://github.com/rancher/rancher/releases 